### PR TITLE
Stack

### DIFF
--- a/problemset/343B-AlternatingCurrent.cc
+++ b/problemset/343B-AlternatingCurrent.cc
@@ -1,0 +1,30 @@
+#include <ios>
+#include <iostream>
+#include <stack>
+#include <string>
+
+bool IsUntangled(const std::string& s) {
+    std::stack<char> config_stack;
+    for (int i = 0; i < s.length(); i++) {
+        if (!config_stack.empty() && config_stack.top() == s[i]) {
+            config_stack.pop();
+        } else {
+            config_stack.push(s[i]);
+        }
+    }
+    return config_stack.empty();
+}
+
+int main(int argc, char* argv[]) {
+    // Fast I/O
+    std::ios_base::sync_with_stdio(false);
+    std::cin.tie(0);
+
+    // Input
+    std::string s;
+    std::cin >> s;
+
+    // Output
+    std::cout << (IsUntangled(s) ? "Yes" : "No") << '\n';
+    return 0;
+}


### PR DESCRIPTION
40381536 | 2018-07-15 17:30:30 | ChopinPlover | B - Alternating Current | GNU C++14 | Accepted | 62 ms | 400 KB

Stack: Cancel out continuous ++ or -- pair recursively. 
The problem is recommended by https://www.codechef.com/certification/prepare#foundation